### PR TITLE
Fixed deprecated port problem.

### DIFF
--- a/seed.go
+++ b/seed.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/conformal/btcwire"
+	"github.com/conformal/btcnet"
 )
 
 func GetSeedsFromDNS(dnsSeeds []string) []string {
@@ -33,7 +33,7 @@ func GetSeedsFromDNS(dnsSeeds []string) []string {
 	seeds := []string{}
 	for ips := range results {
 		for _, ip := range ips {
-			seeds = append(seeds, net.JoinHostPort(ip.String(), btcwire.MainPort))
+			seeds = append(seeds, net.JoinHostPort(ip.String(), btcnet.MainNetParams.DefaultPort))
 		}
 	}
 


### PR DESCRIPTION
A la this commit
https://github.com/conformal/btcwire/commit/c4135db7288579b2503007d1de88936e33d90033
to conformal/btcwire the MainPort was moved to conformal/btcnet. This
changed the API and caused btc-crawl to not be go-get-able.
